### PR TITLE
체스보드와 PawnⓂ️

### DIFF
--- a/ChessGame/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame/ChessGame.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B45686472ADEEC1B002F9EC7 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686462ADEEC1B002F9EC7 /* File.swift */; };
 		B45686492ADEEC28002F9EC7 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686482ADEEC28002F9EC7 /* Position.swift */; };
 		B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456864A2ADEEC32002F9EC7 /* Pawn.swift */; };
+		B456864E2ADEEC7D002F9EC7 /* ChessBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456864D2ADEEC7D002F9EC7 /* ChessBoard.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		B45686462ADEEC1B002F9EC7 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		B45686482ADEEC28002F9EC7 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
 		B456864A2ADEEC32002F9EC7 /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
+		B456864D2ADEEC7D002F9EC7 /* ChessBoard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessBoard.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				B456864C2ADEEC3A002F9EC7 /* ChessPiece */,
+				B456864D2ADEEC7D002F9EC7 /* ChessBoard.swift */,
 			);
 			path = ChessTest;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B45686472ADEEC1B002F9EC7 /* File.swift in Sources */,
+				B456864E2ADEEC7D002F9EC7 /* ChessBoard.swift in Sources */,
 				B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */,
 				B4458F162ADAD6DB00427F6E /* ViewController.swift in Sources */,
 				B45686492ADEEC28002F9EC7 /* Position.swift in Sources */,

--- a/ChessGame/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame/ChessGame.xcodeproj/project.pbxproj
@@ -1,0 +1,612 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B4458F122ADAD6DB00427F6E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F112ADAD6DB00427F6E /* AppDelegate.swift */; };
+		B4458F142ADAD6DB00427F6E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F132ADAD6DB00427F6E /* SceneDelegate.swift */; };
+		B4458F162ADAD6DB00427F6E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F152ADAD6DB00427F6E /* ViewController.swift */; };
+		B4458F192ADAD6DB00427F6E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4458F172ADAD6DB00427F6E /* Main.storyboard */; };
+		B4458F1B2ADAD6DC00427F6E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B4458F1A2ADAD6DC00427F6E /* Assets.xcassets */; };
+		B4458F1E2ADAD6DC00427F6E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4458F1C2ADAD6DC00427F6E /* LaunchScreen.storyboard */; };
+		B4458F292ADAD6DC00427F6E /* ChessGameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F282ADAD6DC00427F6E /* ChessGameTests.swift */; };
+		B4458F332ADAD6DC00427F6E /* ChessGameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */; };
+		B4458F352ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B4458F252ADAD6DC00427F6E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B4458F062ADAD6DB00427F6E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4458F0D2ADAD6DB00427F6E;
+			remoteInfo = ChessGame;
+		};
+		B4458F2F2ADAD6DC00427F6E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B4458F062ADAD6DB00427F6E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4458F0D2ADAD6DB00427F6E;
+			remoteInfo = ChessGame;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		B4458F0E2ADAD6DB00427F6E /* ChessGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4458F112ADAD6DB00427F6E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B4458F132ADAD6DB00427F6E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		B4458F152ADAD6DB00427F6E /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B4458F182ADAD6DB00427F6E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		B4458F1A2ADAD6DC00427F6E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B4458F1D2ADAD6DC00427F6E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B4458F1F2ADAD6DC00427F6E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B4458F242ADAD6DC00427F6E /* ChessGameTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessGameTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4458F282ADAD6DC00427F6E /* ChessGameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameTests.swift; sourceTree = "<group>"; };
+		B4458F2E2ADAD6DC00427F6E /* ChessGameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessGameUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITests.swift; sourceTree = "<group>"; };
+		B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B4458F0B2ADAD6DB00427F6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4458F212ADAD6DC00427F6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4458F2B2ADAD6DC00427F6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B4458F052ADAD6DB00427F6E = {
+			isa = PBXGroup;
+			children = (
+				B4458F102ADAD6DB00427F6E /* ChessGame */,
+				B4458F272ADAD6DC00427F6E /* ChessGameTests */,
+				B4458F312ADAD6DC00427F6E /* ChessGameUITests */,
+				B4458F0F2ADAD6DB00427F6E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B4458F0F2ADAD6DB00427F6E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B4458F0E2ADAD6DB00427F6E /* ChessGame.app */,
+				B4458F242ADAD6DC00427F6E /* ChessGameTests.xctest */,
+				B4458F2E2ADAD6DC00427F6E /* ChessGameUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B4458F102ADAD6DB00427F6E /* ChessGame */ = {
+			isa = PBXGroup;
+			children = (
+				B4458F112ADAD6DB00427F6E /* AppDelegate.swift */,
+				B4458F132ADAD6DB00427F6E /* SceneDelegate.swift */,
+				B4458F152ADAD6DB00427F6E /* ViewController.swift */,
+				B4458F172ADAD6DB00427F6E /* Main.storyboard */,
+				B4458F1A2ADAD6DC00427F6E /* Assets.xcassets */,
+				B4458F1C2ADAD6DC00427F6E /* LaunchScreen.storyboard */,
+				B4458F1F2ADAD6DC00427F6E /* Info.plist */,
+			);
+			path = ChessGame;
+			sourceTree = "<group>";
+		};
+		B4458F272ADAD6DC00427F6E /* ChessGameTests */ = {
+			isa = PBXGroup;
+			children = (
+				B4458F282ADAD6DC00427F6E /* ChessGameTests.swift */,
+			);
+			path = ChessGameTests;
+			sourceTree = "<group>";
+		};
+		B4458F312ADAD6DC00427F6E /* ChessGameUITests */ = {
+			isa = PBXGroup;
+			children = (
+				B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */,
+				B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */,
+			);
+			path = ChessGameUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B4458F0D2ADAD6DB00427F6E /* ChessGame */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B4458F382ADAD6DC00427F6E /* Build configuration list for PBXNativeTarget "ChessGame" */;
+			buildPhases = (
+				B4458F0A2ADAD6DB00427F6E /* Sources */,
+				B4458F0B2ADAD6DB00427F6E /* Frameworks */,
+				B4458F0C2ADAD6DB00427F6E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChessGame;
+			productName = ChessGame;
+			productReference = B4458F0E2ADAD6DB00427F6E /* ChessGame.app */;
+			productType = "com.apple.product-type.application";
+		};
+		B4458F232ADAD6DC00427F6E /* ChessGameTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B4458F3B2ADAD6DC00427F6E /* Build configuration list for PBXNativeTarget "ChessGameTests" */;
+			buildPhases = (
+				B4458F202ADAD6DC00427F6E /* Sources */,
+				B4458F212ADAD6DC00427F6E /* Frameworks */,
+				B4458F222ADAD6DC00427F6E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B4458F262ADAD6DC00427F6E /* PBXTargetDependency */,
+			);
+			name = ChessGameTests;
+			productName = ChessGameTests;
+			productReference = B4458F242ADAD6DC00427F6E /* ChessGameTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		B4458F2D2ADAD6DC00427F6E /* ChessGameUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B4458F3E2ADAD6DC00427F6E /* Build configuration list for PBXNativeTarget "ChessGameUITests" */;
+			buildPhases = (
+				B4458F2A2ADAD6DC00427F6E /* Sources */,
+				B4458F2B2ADAD6DC00427F6E /* Frameworks */,
+				B4458F2C2ADAD6DC00427F6E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B4458F302ADAD6DC00427F6E /* PBXTargetDependency */,
+			);
+			name = ChessGameUITests;
+			productName = ChessGameUITests;
+			productReference = B4458F2E2ADAD6DC00427F6E /* ChessGameUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B4458F062ADAD6DB00427F6E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					B4458F0D2ADAD6DB00427F6E = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					B4458F232ADAD6DC00427F6E = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = B4458F0D2ADAD6DB00427F6E;
+					};
+					B4458F2D2ADAD6DC00427F6E = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = B4458F0D2ADAD6DB00427F6E;
+					};
+				};
+			};
+			buildConfigurationList = B4458F092ADAD6DB00427F6E /* Build configuration list for PBXProject "ChessGame" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B4458F052ADAD6DB00427F6E;
+			productRefGroup = B4458F0F2ADAD6DB00427F6E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B4458F0D2ADAD6DB00427F6E /* ChessGame */,
+				B4458F232ADAD6DC00427F6E /* ChessGameTests */,
+				B4458F2D2ADAD6DC00427F6E /* ChessGameUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B4458F0C2ADAD6DB00427F6E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B4458F1E2ADAD6DC00427F6E /* LaunchScreen.storyboard in Resources */,
+				B4458F1B2ADAD6DC00427F6E /* Assets.xcassets in Resources */,
+				B4458F192ADAD6DB00427F6E /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4458F222ADAD6DC00427F6E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4458F2C2ADAD6DC00427F6E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B4458F0A2ADAD6DB00427F6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B4458F162ADAD6DB00427F6E /* ViewController.swift in Sources */,
+				B4458F122ADAD6DB00427F6E /* AppDelegate.swift in Sources */,
+				B4458F142ADAD6DB00427F6E /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4458F202ADAD6DC00427F6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B4458F292ADAD6DC00427F6E /* ChessGameTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4458F2A2ADAD6DC00427F6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B4458F332ADAD6DC00427F6E /* ChessGameUITests.swift in Sources */,
+				B4458F352ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B4458F262ADAD6DC00427F6E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B4458F0D2ADAD6DB00427F6E /* ChessGame */;
+			targetProxy = B4458F252ADAD6DC00427F6E /* PBXContainerItemProxy */;
+		};
+		B4458F302ADAD6DC00427F6E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B4458F0D2ADAD6DB00427F6E /* ChessGame */;
+			targetProxy = B4458F2F2ADAD6DC00427F6E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		B4458F172ADAD6DB00427F6E /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B4458F182ADAD6DB00427F6E /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		B4458F1C2ADAD6DC00427F6E /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B4458F1D2ADAD6DC00427F6E /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		B4458F362ADAD6DC00427F6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B4458F372ADAD6DC00427F6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B4458F392ADAD6DC00427F6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7MS89TXQ5T;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChessGame/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = camosss.ChessGame;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B4458F3A2ADAD6DC00427F6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7MS89TXQ5T;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChessGame/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = camosss.ChessGame;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		B4458F3C2ADAD6DC00427F6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7MS89TXQ5T;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = camosss.ChessGameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChessGame.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ChessGame";
+			};
+			name = Debug;
+		};
+		B4458F3D2ADAD6DC00427F6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7MS89TXQ5T;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = camosss.ChessGameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChessGame.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ChessGame";
+			};
+			name = Release;
+		};
+		B4458F3F2ADAD6DC00427F6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7MS89TXQ5T;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = camosss.ChessGameUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ChessGame;
+			};
+			name = Debug;
+		};
+		B4458F402ADAD6DC00427F6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7MS89TXQ5T;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = camosss.ChessGameUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ChessGame;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B4458F092ADAD6DB00427F6E /* Build configuration list for PBXProject "ChessGame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B4458F362ADAD6DC00427F6E /* Debug */,
+				B4458F372ADAD6DC00427F6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B4458F382ADAD6DC00427F6E /* Build configuration list for PBXNativeTarget "ChessGame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B4458F392ADAD6DC00427F6E /* Debug */,
+				B4458F3A2ADAD6DC00427F6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B4458F3B2ADAD6DC00427F6E /* Build configuration list for PBXNativeTarget "ChessGameTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B4458F3C2ADAD6DC00427F6E /* Debug */,
+				B4458F3D2ADAD6DC00427F6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B4458F3E2ADAD6DC00427F6E /* Build configuration list for PBXNativeTarget "ChessGameUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B4458F3F2ADAD6DC00427F6E /* Debug */,
+				B4458F402ADAD6DC00427F6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B4458F062ADAD6DB00427F6E /* Project object */;
+}

--- a/ChessGame/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame/ChessGame.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		B4458F292ADAD6DC00427F6E /* ChessGameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F282ADAD6DC00427F6E /* ChessGameTests.swift */; };
 		B4458F332ADAD6DC00427F6E /* ChessGameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */; };
 		B4458F352ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */; };
+		B45686452ADEEC12002F9EC7 /* PieceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686442ADEEC12002F9EC7 /* PieceType.swift */; };
+		B45686472ADEEC1B002F9EC7 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686462ADEEC1B002F9EC7 /* File.swift */; };
+		B45686492ADEEC28002F9EC7 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686482ADEEC28002F9EC7 /* Position.swift */; };
+		B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456864A2ADEEC32002F9EC7 /* Pawn.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +53,10 @@
 		B4458F2E2ADAD6DC00427F6E /* ChessGameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessGameUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITests.swift; sourceTree = "<group>"; };
 		B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B45686442ADEEC12002F9EC7 /* PieceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceType.swift; sourceTree = "<group>"; };
+		B45686462ADEEC1B002F9EC7 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
+		B45686482ADEEC28002F9EC7 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
+		B456864A2ADEEC32002F9EC7 /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				B4458F102ADAD6DB00427F6E /* ChessGame */,
+				B45686432ADEEBFC002F9EC7 /* ChessTest */,
 				B4458F272ADAD6DC00427F6E /* ChessGameTests */,
 				B4458F312ADAD6DC00427F6E /* ChessGameUITests */,
 				B4458F0F2ADAD6DB00427F6E /* Products */,
@@ -125,6 +134,25 @@
 				B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */,
 			);
 			path = ChessGameUITests;
+			sourceTree = "<group>";
+		};
+		B45686432ADEEBFC002F9EC7 /* ChessTest */ = {
+			isa = PBXGroup;
+			children = (
+				B456864C2ADEEC3A002F9EC7 /* ChessPiece */,
+			);
+			path = ChessTest;
+			sourceTree = "<group>";
+		};
+		B456864C2ADEEC3A002F9EC7 /* ChessPiece */ = {
+			isa = PBXGroup;
+			children = (
+				B45686442ADEEC12002F9EC7 /* PieceType.swift */,
+				B45686462ADEEC1B002F9EC7 /* File.swift */,
+				B45686482ADEEC28002F9EC7 /* Position.swift */,
+				B456864A2ADEEC32002F9EC7 /* Pawn.swift */,
+			);
+			path = ChessPiece;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -258,8 +286,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B45686472ADEEC1B002F9EC7 /* File.swift in Sources */,
+				B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */,
 				B4458F162ADAD6DB00427F6E /* ViewController.swift in Sources */,
+				B45686492ADEEC28002F9EC7 /* Position.swift in Sources */,
 				B4458F122ADAD6DB00427F6E /* AppDelegate.swift in Sources */,
+				B45686452ADEEC12002F9EC7 /* PieceType.swift in Sources */,
 				B4458F142ADAD6DB00427F6E /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ChessGame/ChessGame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ChessGame/ChessGame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ChessGame/ChessGame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ChessGame/ChessGame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ChessGame/ChessGame/AppDelegate.swift
+++ b/ChessGame/ChessGame/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/14/23.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/ChessGame/ChessGame/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ChessGame/ChessGame/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ChessGame/ChessGame/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ChessGame/ChessGame/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ChessGame/ChessGame/Assets.xcassets/Contents.json
+++ b/ChessGame/ChessGame/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ChessGame/ChessGame/Base.lproj/LaunchScreen.storyboard
+++ b/ChessGame/ChessGame/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ChessGame/ChessGame/Base.lproj/Main.storyboard
+++ b/ChessGame/ChessGame/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ChessGame/ChessGame/Info.plist
+++ b/ChessGame/ChessGame/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ChessGame/ChessGame/SceneDelegate.swift
+++ b/ChessGame/ChessGame/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/14/23.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/ChessGame/ChessGame/ViewController.swift
+++ b/ChessGame/ChessGame/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/14/23.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/ChessGame/ChessGameTests/ChessGameTests.swift
+++ b/ChessGame/ChessGameTests/ChessGameTests.swift
@@ -25,4 +25,16 @@ final class ChessGameTests: XCTestCase {
     func test_checkInitialPosition() {
         XCTAssertTrue(sut.checkInitialPosition())
     }
+
+    func test_black_movePiece() {
+        let from = Pawn(pieceType: .black, position: Position(rank: 2, file: .D))
+        let to = Pawn(pieceType: .black, position: Position(rank: 3, file: .E))
+        XCTAssertTrue(sut.movePiece(from: from, to: to))
+    }
+
+    func test_white_movePiece() {
+        let from = Pawn(pieceType: .white, position: Position(rank: 7, file: .D))
+        let to = Pawn(pieceType: .white, position: Position(rank: 6, file: .E))
+        XCTAssertTrue(sut.movePiece(from: from, to: to))
+    }
 }

--- a/ChessGame/ChessGameTests/ChessGameTests.swift
+++ b/ChessGame/ChessGameTests/ChessGameTests.swift
@@ -1,0 +1,36 @@
+//
+//  ChessGameTests.swift
+//  ChessGameTests
+//
+//  Created by 강호성 on 10/14/23.
+//
+
+import XCTest
+@testable import ChessGame
+
+final class ChessGameTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/ChessGame/ChessGameTests/ChessGameTests.swift
+++ b/ChessGame/ChessGameTests/ChessGameTests.swift
@@ -10,27 +10,19 @@ import XCTest
 
 final class ChessGameTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    private var sut: ChessBoard!
+
+    override func setUp() {
+        sut = ChessBoard()
+        super.setUp()
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func test_checkInitialPosition() {
+        XCTAssertTrue(sut.checkInitialPosition())
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/ChessGame/ChessGameUITests/ChessGameUITests.swift
+++ b/ChessGame/ChessGameUITests/ChessGameUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ChessGameUITests.swift
+//  ChessGameUITests
+//
+//  Created by 강호성 on 10/14/23.
+//
+
+import XCTest
+
+final class ChessGameUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/ChessGame/ChessGameUITests/ChessGameUITestsLaunchTests.swift
+++ b/ChessGame/ChessGameUITests/ChessGameUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ChessGameUITestsLaunchTests.swift
+//  ChessGameUITests
+//
+//  Created by 강호성 on 10/14/23.
+//
+
+import XCTest
+
+final class ChessGameUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ChessGame/ChessTest/ChessBoard.swift
+++ b/ChessGame/ChessTest/ChessBoard.swift
@@ -1,0 +1,93 @@
+//
+//  ChessBoard.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+final class ChessBoard {
+
+    // MARK: - Property
+
+    private var board = Pawn.initPosition()
+
+    // MARK: - Init
+
+    /// 체스 프로그램을 시작하면 흑/백 Pawn을 초기화한다.
+    init() {
+        for file in File.allCases {
+            board[1][file.index] = Pawn(pieceType: .black, position: Position(rank: 1, file: file))
+        }
+        for file in File.allCases {
+            board[6][file.index] = Pawn(pieceType: .white, position: Position(rank: 6, file: file))
+        }
+    }
+
+    // MARK: - Display
+
+    /// 1-rank부터 8-rank까지 rank 문자열로 보드 위에 체스말을 리턴
+    func display() -> String {
+        var boardString = ""
+        var count = 0
+
+        print(" ABCDEFGH")
+        for row in board {
+            count += 1
+            let rowString = row.map { $0.pieceType.rawValue }.joined(separator: "")
+            boardString += "\(count)" + rowString + "\n"
+        }
+        print(boardString)
+        return boardString
+    }
+
+    // MARK: - Initial Position
+
+    /// 입력: 초기화 메서드 테스트 실행
+    func checkInitialPosition() -> Bool {
+        return checkInitialPiecePosition() && checkMaximumPieceCounts()
+    }
+
+    /// 검증1: 체스말 초기 위치가 아니면 생성하지 않는다. (흑색은 2-rank 또는 백색 7-rank)
+    private func checkInitialPiecePosition() -> Bool {
+        for rank in 1...8 {
+            for file in File.allCases {
+                let piece = board[rank - 1][file.index]
+                if (rank == 2 || rank == 7) && (piece.pieceType != .black && piece.pieceType != .white) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    /// 검증2: 체스말 종류별로 최대 개수보다 많이 생성할 수는 없다.
+    /// 검증3: Pawn는 색상별로 8개만 가능하다.
+    private func checkMaximumPieceCounts() -> Bool {
+        var blackPawnsCount = 0
+        var whitePawnsCount = 0
+
+        for rank in 1...8 {
+            for file in File.allCases {
+                let piece = board[rank - 1][file.index]
+
+                if piece.pieceType == .black {
+                    blackPawnsCount += 1
+                } else if piece.pieceType == .white {
+                    whitePawnsCount += 1
+                }
+            }
+        }
+
+        if blackPawnsCount > 8 || whitePawnsCount > 8 {
+            return false
+        }
+
+        if blackPawnsCount != 8 || whitePawnsCount != 8 {
+            return false
+        }
+
+        return true
+    }
+}

--- a/ChessGame/ChessTest/ChessBoard.swift
+++ b/ChessGame/ChessTest/ChessBoard.swift
@@ -90,4 +90,73 @@ final class ChessBoard {
 
         return true
     }
+
+    // MARK: - Move Chess Piece
+
+    /// 입력: 움직이려는 말이 있는 위치(from)와 이동하려는 위치(to)를 차례대로 입력받아서 말을 이동한다.
+    func movePiece(from: Pawn, to: Pawn) -> Bool {
+        return canMove(from: from, to: to) &&
+        isValidRankMove(from: from, to: to) &&
+        isOneSpaceMove(from: from, to: to)
+    }
+
+    private func canMove(from: Pawn, to: Pawn) -> Bool {
+        let pawnAtFromPosition = board[from.position.rank - 1][from.position.file.index]
+        let pawnAtToPosition = board[to.position.rank - 1][to.position.file.index]
+
+        /// 검증1: 형식에 맞지 않으면 다시 입력받는다.
+        guard from.position.isValidPosition() && to.position.isValidPosition() else {
+            return false
+        }
+
+        /// 검증2: from 위치에 동일한 pieceType의 체스말이 존재하는지 확인한다.
+        if pawnAtFromPosition.pieceType != from.pieceType {
+            return false
+        }
+
+        /// 검증3: from과 to의 체스말은 동일할 수 없다.
+        if from.pieceType != to.pieceType {
+            return false
+        }
+
+        /// 검증4: 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
+        if pawnAtToPosition.pieceType == to.pieceType {
+            return false
+        }
+
+        return true
+    }
+
+    /// 검증5 - 백색은 큰 rank에서 더 작은 rank로 움직일 수 있고, 흑색은 작은 rank에서 더 큰 rank로 움직일 수 있다.
+    private func isValidRankMove(from: Pawn, to: Pawn) -> Bool {
+        let fromPieceRank = from.position.rank
+        let toPieceRank = to.position.rank
+
+        switch from.pieceType {
+        case .black:
+            if fromPieceRank >= toPieceRank {
+                return false
+            }
+        case .white:
+            if fromPieceRank <= toPieceRank {
+                return false
+            }
+        case .dot:
+            return true
+        }
+
+        return true
+    }
+
+    /// 검증6 - 1칸만 움직일 수 있다. (직선/대각선)
+    private func isOneSpaceMove(from: Pawn, to: Pawn) -> Bool {
+        let rankDifference = abs(from.position.rank - to.position.rank)
+        let fileDifference = abs(from.position.file.index - to.position.file.index)
+
+        if rankDifference > 1 || fileDifference > 1 {
+            return false
+        }
+
+        return true
+    }
 }

--- a/ChessGame/ChessTest/ChessBoard.swift
+++ b/ChessGame/ChessTest/ChessBoard.swift
@@ -30,15 +30,10 @@ final class ChessBoard {
     /// 1-rank부터 8-rank까지 rank 문자열로 보드 위에 체스말을 리턴
     func display() -> String {
         var boardString = ""
-        var count = 0
-
-        print(" ABCDEFGH")
         for row in board {
-            count += 1
             let rowString = row.map { $0.pieceType.rawValue }.joined(separator: "")
-            boardString += "\(count)" + rowString + "\n"
+            boardString += rowString + "\n"
         }
-        print(boardString)
         return boardString
     }
 

--- a/ChessGame/ChessTest/ChessPiece/File.swift
+++ b/ChessGame/ChessTest/ChessPiece/File.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+enum File: String, CaseIterable {
+    case A
+    case B
+    case C
+    case D
+    case E
+    case F
+    case G
+    case H
+
+    var index: Int {
+        switch self {
+        case .A: 0
+        case .B: 1
+        case .C: 2
+        case .D: 3
+        case .E: 4
+        case .F: 5
+        case .G: 6
+        case .H: 7
+        }
+    }
+}

--- a/ChessGame/ChessTest/ChessPiece/Pawn.swift
+++ b/ChessGame/ChessTest/ChessPiece/Pawn.swift
@@ -1,0 +1,27 @@
+//
+//  Pawn.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+struct Pawn {
+    var pieceType: PieceType
+    let position: Position
+
+    static func initPosition() -> [[Pawn]] {
+        var board: [[Pawn]] = []
+
+        for row in 1...8 {
+            var rowPieces: [Pawn] = []
+            for file in File.allCases {
+                rowPieces.append(Pawn(pieceType: .dot, position: Position(rank: row, file: file)))
+            }
+            board.append(rowPieces)
+        }
+
+        return board
+    }
+}

--- a/ChessGame/ChessTest/ChessPiece/PieceType.swift
+++ b/ChessGame/ChessTest/ChessPiece/PieceType.swift
@@ -1,0 +1,14 @@
+//
+//  PieceType.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+enum PieceType: String {
+    case black = "♟"
+    case white = "♙"
+    case dot = "."
+}

--- a/ChessGame/ChessTest/ChessPiece/Position.swift
+++ b/ChessGame/ChessTest/ChessPiece/Position.swift
@@ -1,0 +1,19 @@
+//
+//  Position.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+struct Position {
+    let rank: Int   /// row
+    let file: File  /// column
+
+    /// 유효성 검증
+    func isValidPosition() -> Bool {
+        return rank >= 1 && rank <= 8 &&
+        file.index >= 0 && file.index < File.allCases.count
+    }
+}


### PR DESCRIPTION
### 요구사항
- 입출력 뷰와 핵심 로직을 분리해서 설계하고 입출력을 제외한 **핵심 로직만 구현**해야 한다.
- 더 작은 단위나 반복되는 코드가 있다면 일반화해서 별도 클래스로 구현해야 한다.
- 프로그램을 설계할 때 **입력 → 검증 → 처리/계산 → 형식 → 출력** 단계를 구분한다.

### 작업내역
- Board
    - 8x8 크기 체스판에 체스말(Piece) 존재 여부를 관리한다.
        - 가로: rank (row에 해당)
        - 세로: file (column에 해당)
- display()
    - 1-rank부터 8-rank까지 rank 문자열 배열로 보드 위에 체스말을 리턴한다.
- 초기화
    - 초기화 메서드 테스트 실행
       - **검증1**: 체스말 초기 위치가 아니면 생성하지 않는다. (흑색은 2-rank 또는 백색 7-rank)
       - **검증2**: 체스말 종류별로 최대 개수보다 많이 생성할 수는 없다.
       - **검증3**: Pawn는 색상별로 8개만 가능하다.
- canMove
    - **입력** - 움직이려는 말이 있는 위치(from)와 이동하려는 위치(to)를 차례대로 입력받아서 말을 이동한다.
       - **검증1**: 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
       - **검증2**: from 위치에 동일한 pieceType의 체스말이 존재하는지 확인한다.
       - **검증3**: from과 to의 체스말은 동일할 수 없다.
       - **검증4**: 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
- movePiece
    - **입력** - 움직이려는 말이 있는 위치(from)와 이동하려는 위치(to)를 차례대로 입력받아서 말을 이동한다.
       - **검증1**: 백색은 큰 rank에서 더 작은 rank로 움직일 수 있고, 흑색은 작은 rank에서 더 큰 rank로 움직일 수 있다.
       - **검증2**: 1칸만 움직일 수 있다. (직선/대각선)

### 학습 진행 내용
- 각 케이스별 유효성 검증을 위한 메서드를 분리하여 작업
- 체스말 움직임의 테스트 과정에서 각 케이스별 테스트 케이스를 만들어서 진행하는지에 대한 고민(궁금증)
   - 현재는 각 type별(black/white)로 움직임에 대한 유효성을 검증하는 테스트 케이스만 존재
- 검증 이후 '처리/계산 → 형식' 단계를 단위 테스트를 통해 어떤 방식으로 테스트하는지에 대한 추가 학습 필요
<br>



